### PR TITLE
fix: バッテリーレベルを100倍してパーセント表示を修正

### DIFF
--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -58,7 +58,7 @@ function formatAccuracy(accuracy: number | null | undefined): string {
 }
 
 function formatBatteryLevel(level: number): string {
-  return `${Math.round(level)}%`;
+  return `${Math.round(level * 100)}%`;
 }
 
 const batteryStateLabels: Record<BatteryState, string> = {


### PR DESCRIPTION
battery_levelが0.0〜1.0の範囲で返されるため、表示時に100倍する必要があった

https://claude.ai/code/session_016mXDNNeSQtXJ8FiwpRsXjP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
  * バッテリー残量の表示形式を修正しました。バッテリーレベルの計算ロジックを改善し、より正確なパーセンテージが表示されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->