### PR TITLE
fix: バッテリー充電状態の整数値を日本語ラベルに変換

### DIFF
--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -68,8 +68,20 @@ const batteryStateLabels: Record<BatteryState, string> = {
   unknown: "不明",
 };
 
-function formatBatteryState(state: BatteryState | null): string {
-  if (state === null) return "-";
+// Expo Battery.BatteryState の整数値に対応するマッピング
+const batteryStateFromNumber: Record<number, BatteryState> = {
+  0: "unknown",
+  1: "unplugged",
+  2: "charging",
+  3: "full",
+};
+
+function formatBatteryState(state: BatteryState | number | null): string {
+  if (state === null || state === undefined) return "-";
+  if (typeof state === "number") {
+    const mapped = batteryStateFromNumber[state];
+    return mapped ? batteryStateLabels[mapped] : "不明";
+  }
   return batteryStateLabels[state] || String(state);
 }
 


### PR DESCRIPTION
サーバーからExpo Battery.BatteryStateの整数値(0-3)で送られてくる
充電状態を「充電中」「未接続」「満充電」「不明」の日本語表示に変換。

https://claude.ai/code/session_01WHxNXXYN446PRXBh9jWjnX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * バッテリー状態の表示処理を改善し、数値入力への対応とnull/undefined値の適切な処理を追加しました。不明な状態は「不明」と表示されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->