### PR TITLE
fix: マップ移動時にマーカーの吹き出しが消えないように修正

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -102,6 +102,12 @@ export default function MapScreen() {
 
   // マップ背景をタップしたら吹き出しを明示的に閉じる
   const handleMapPress = useCallback(() => {
+    if (selectedMarkerIdRef.current) {
+      const marker = markerRefs.current.get(selectedMarkerIdRef.current);
+      if (marker) {
+        marker.hideCallout();
+      }
+    }
     selectedMarkerIdRef.current = null;
   }, []);
 

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -366,6 +366,7 @@ export default function MapScreen() {
                         title={trajectory.deviceId}
                         description="最新位置"
                         pinColor={getDeviceColor(trajectory.deviceId, state.deviceIds)}
+                        stopPropagation
                         onPress={() => handleMarkerPress(trajectory.deviceId)}
                         onCalloutPress={() => handleCalloutPress(trajectory.deviceId)}
                       />


### PR DESCRIPTION
マーカーをタップして表示された吹き出し（callout）が、マップのパン・ズーム操作時に
自動的に消えてしまう問題を修正。onRegionChangeComplete で選択中のマーカーの
showCallout() を再呼び出しすることで、ユーザーが明示的に閉じるまで吹き出しを
表示し続けるようにした。

吹き出しの明示的な解除方法:
- マップの背景をタップ
- 吹き出し自体をタップ
- 別のマーカーをタップ（切り替え）

https://claude.ai/code/session_01TuXxMDD3bmhRDQ5QN2NYxi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * マップ上のマーカー選択・操作を強化しました。
  * マーカーをタップして選択し、詳細情報（コールアウト）を表示できます。
  * マップ背景をタップすると現在の選択が解除されます。
  * コールアウトをタップして閉じられるようになりました。
  * 地図の移動後も選択中のマーカーの詳細が自動的に再表示されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->