### PR TITLE
feat: マップピンの吹き出しに状態タグ(到着/接近中/通過中/移動中)を表示

### DIFF
--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -8,7 +8,7 @@ interface LocationCardProps {
   update: LocationUpdate;
 }
 
-const stateConfig: Record<MovingState, { label: string; bgClass: string; textClass: string; colorKey: keyof ReturnType<typeof useColors> }> = {
+export const stateConfig: Record<MovingState, { label: string; bgClass: string; textClass: string; colorKey: keyof ReturnType<typeof useColors> }> = {
   arrived: { label: "到着", bgClass: "bg-success/20", textClass: "text-success", colorKey: "success" },
   approaching: { label: "接近中", bgClass: "bg-warning/20", textClass: "text-warning", colorKey: "warning" },
   passing: { label: "通過中", bgClass: "bg-primary/20", textClass: "text-primary", colorKey: "primary" },
@@ -16,7 +16,7 @@ const stateConfig: Record<MovingState, { label: string; bgClass: string; textCla
 };
 
 // 未知のstate値に対するフォールバック
-const defaultStateConfig = { label: "不明", bgClass: "bg-muted/20", textClass: "text-muted", colorKey: "muted" as const };
+export const defaultStateConfig = { label: "不明", bgClass: "bg-muted/20", textClass: "text-muted", colorKey: "muted" as const };
 
 function formatCoordinate(value: number, type: "lat" | "lng"): string {
   const abs = Math.abs(value);

--- a/hooks/use-device-trajectory.ts
+++ b/hooks/use-device-trajectory.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { LocationUpdate } from "@/lib/types/location";
+import type { LocationUpdate, MovingState } from "@/lib/types/location";
 
 export interface Coordinate {
   latitude: number;
@@ -10,6 +10,7 @@ export interface DeviceTrajectory {
   deviceId: string;
   coordinates: Coordinate[];
   latestPosition: Coordinate | null;
+  latestState: MovingState | null;
 }
 
 /**
@@ -50,11 +51,14 @@ export function useDeviceTrajectory(
 
       const latestPosition =
         coordinates.length > 0 ? coordinates[coordinates.length - 1] : null;
+      const latestState =
+        sorted.length > 0 ? sorted[sorted.length - 1].state : null;
 
       trajectories.push({
         deviceId,
         coordinates,
         latestPosition,
+        latestState,
       });
     }
 


### PR DESCRIPTION
タイムライン画面と同じ状態タグをマップのマーカー吹き出しに追加。
DeviceTrajectoryにlatestStateを追加し、カスタムCalloutで
デバイス名と色付きの状態バッジを表示するように変更。

https://claude.ai/code/session_013cy6jgMDJhAv3YF7LUeaxv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * マップマーカーをタップするとデバイス情報がポップアップで表示されるようになりました。デバイスIDと最新位置情報、色分けされたステータスバッジが表示されます。
  * マップ表示がより詳細で分かりやすくなり、各デバイスの現在のステータスが視覚的に確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->