### PR TITLE
feat: マップピンの吹き出しに移動速度・精度・バッテリー残量を表示

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -17,7 +17,7 @@ import Animated, {
 
 import { ScreenContainer } from "@/components/screen-container";
 import { ConnectionStatusBadge } from "@/components/connection-status";
-import { stateConfig, defaultStateConfig } from "@/components/location-card";
+import { stateConfig, defaultStateConfig, formatSpeed, formatAccuracy, formatBatteryLevel } from "@/components/location-card";
 import { useLocation } from "@/lib/location-store";
 import { useColors } from "@/hooks/use-colors";
 import { cn } from "@/lib/utils";
@@ -399,6 +399,11 @@ export default function MapScreen() {
                                   </View>
                                 </View>
                                 <Text style={styles.calloutDescription}>最新位置</Text>
+                                <View style={styles.calloutMetrics}>
+                                  <Text style={styles.calloutMetricText}>🏎️ {formatSpeed(trajectory.latestSpeed)}</Text>
+                                  <Text style={styles.calloutMetricText}>🎯 {formatAccuracy(trajectory.latestAccuracy)}</Text>
+                                  <Text style={styles.calloutMetricText}>🔋 {trajectory.latestBatteryLevel != null ? formatBatteryLevel(trajectory.latestBatteryLevel) : "-"}</Text>
+                                </View>
                               </View>
                             </Callout>
                           )}
@@ -484,5 +489,14 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: "#687076",
     marginTop: 4,
+  },
+  calloutMetrics: {
+    flexDirection: "row",
+    gap: 8,
+    marginTop: 4,
+  },
+  calloutMetricText: {
+    fontSize: 11,
+    color: "#687076",
   },
 });

--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -41,7 +41,7 @@ function formatTimestamp(timestamp: number): string {
   });
 }
 
-function formatSpeed(speed: number | null | undefined): string {
+export function formatSpeed(speed: number | null | undefined): string {
   if (speed === null || speed === undefined || speed === -1) {
     return "-";
   }
@@ -50,14 +50,14 @@ function formatSpeed(speed: number | null | undefined): string {
   return `${kmh.toFixed(1)} km/h`;
 }
 
-function formatAccuracy(accuracy: number | null | undefined): string {
+export function formatAccuracy(accuracy: number | null | undefined): string {
   if (accuracy === null || accuracy === undefined) {
     return "-";
   }
   return `${accuracy.toFixed(0)}m`;
 }
 
-function formatBatteryLevel(level: number): string {
+export function formatBatteryLevel(level: number): string {
   return `${Math.round(level * 100)}%`;
 }
 

--- a/hooks/use-device-trajectory.ts
+++ b/hooks/use-device-trajectory.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { LocationUpdate, MovingState } from "@/lib/types/location";
+import type { LocationUpdate, MovingState, BatteryState } from "@/lib/types/location";
 
 export interface Coordinate {
   latitude: number;
@@ -11,6 +11,10 @@ export interface DeviceTrajectory {
   coordinates: Coordinate[];
   latestPosition: Coordinate | null;
   latestState: MovingState | null;
+  latestSpeed: number | null | undefined;
+  latestAccuracy: number | null | undefined;
+  latestBatteryLevel: number | null;
+  latestBatteryState: BatteryState | number | null;
 }
 
 /**
@@ -49,16 +53,20 @@ export function useDeviceTrajectory(
         longitude: u.coords.longitude,
       }));
 
+      const latestUpdate = sorted.length > 0 ? sorted[sorted.length - 1] : null;
       const latestPosition =
         coordinates.length > 0 ? coordinates[coordinates.length - 1] : null;
-      const latestState =
-        sorted.length > 0 ? sorted[sorted.length - 1].state : null;
+      const latestState = latestUpdate?.state ?? null;
 
       trajectories.push({
         deviceId,
         coordinates,
         latestPosition,
         latestState,
+        latestSpeed: latestUpdate?.coords.speed ?? null,
+        latestAccuracy: latestUpdate?.coords.accuracy ?? null,
+        latestBatteryLevel: latestUpdate?.battery_level ?? null,
+        latestBatteryState: latestUpdate?.battery_state ?? null,
       });
     }
 


### PR DESCRIPTION
最新位置の下段に🏎️速度、🎯精度、🔋バッテリー残量を
タイムライン画面と同様の絵文字+値ペア形式で表示する。

DeviceTrajectoryインターフェースを拡張し、最新の速度・精度・
バッテリー情報を保持するようにした。

https://claude.ai/code/session_01N1zhUcZx3SnMiPSgrzuLk4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * マップビューのコールアウトUIに、デバイスの速度（🏎️）、精度（🎯）、バッテリーレベル（🔋）を表示する新しいメトリクス行を追加しました。バッテリーレベルは利用可能な場合のみ表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->