### PR TITLE
feat: タイムラインとマップに路線ID(line_id)フィルターを追加

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -98,6 +98,7 @@ const config: ExpoConfig = {
   },
   extra: {
     thqWsAuthToken: process.env.THQ_WS_AUTH_TOKEN || "",
+    trainlcdGqlUrl: process.env.TRAINLCD_GQL_URL || "",
     eas: {
       projectId:
         process.env.EAS_BUILD_PROJECT_ID ||

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/hooks/use-device-trajectory";
 import { getDeviceColor } from "@/constants/map-colors";
 import type { MovingState } from "@/lib/types/location";
+import { useLineNames } from "@/hooks/use-line-names";
 
 // react-native-maps は Web では使えないので条件付きインポート
 let MapView: typeof import("react-native-maps").default | null = null;
@@ -55,6 +56,7 @@ export default function MapScreen() {
   const [selectedDevices, setSelectedDevices] = useState<Set<string>>(new Set());
   const [selectedRoutes, setSelectedRoutes] = useState<Set<string>>(new Set());
   const [isFilterExpanded, setIsFilterExpanded] = useState(true);
+  const lineNames = useLineNames(state.lineIds);
   const mapRef = useRef<MapViewRef | null>(null);
   const [isFollowing, setIsFollowing] = useState(true);
   const selectedMarkerIdRef = useRef<string | null>(null);
@@ -361,7 +363,7 @@ export default function MapScreen() {
               {/* Route ID Filter (only show if there are routes) */}
               {state.lineIds.length > 0 && (
                 <View className="mt-3">
-                  <Text className="text-sm text-muted mb-2">路線ID</Text>
+                  <Text className="text-sm text-muted mb-2">路線</Text>
                   <ScrollView
                     horizontal
                     showsHorizontalScrollIndicator={false}
@@ -413,7 +415,7 @@ export default function MapScreen() {
                             )}
                             numberOfLines={1}
                           >
-                            {lineId}
+                            {lineNames[lineId] ? <><Text style={{ fontWeight: "bold" }}>{lineNames[lineId]}</Text>({lineId})</> : lineId}
                           </Text>
                         </View>
                       </TouchableOpacity>
@@ -500,6 +502,9 @@ export default function MapScreen() {
                                   </View>
                                 </View>
                                 <Text style={styles.calloutDescription}>最新位置</Text>
+                                {trajectory.latestLineId && lineNames[trajectory.latestLineId] && (
+                                  <Text style={styles.calloutLineName}>🚆 {lineNames[trajectory.latestLineId]}</Text>
+                                )}
                                 <View style={styles.calloutMetrics}>
                                   <Text style={styles.calloutMetricText}>🏎️ {formatSpeed(trajectory.latestSpeed)}</Text>
                                   <Text style={styles.calloutMetricText}>🎯 {formatAccuracy(trajectory.latestAccuracy)}</Text>
@@ -590,6 +595,12 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: "#687076",
     marginTop: 4,
+    marginBottom: 4,
+  },
+  calloutLineName: {
+    fontSize: 12,
+    color: "#687076",
+    marginTop: 2,
   },
   calloutMetrics: {
     flexDirection: "row",

--- a/app/(tabs)/timeline.tsx
+++ b/app/(tabs)/timeline.tsx
@@ -25,6 +25,7 @@ import { useLocation } from "@/lib/location-store";
 import type { LocationUpdate, MovingState } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 import { useColors } from "@/hooks/use-colors";
+import { useLineNames } from "@/hooks/use-line-names";
 
 // 状態フィルターオプションの定義
 const MOVING_STATES: { value: MovingState; label: string }[] = [
@@ -48,6 +49,7 @@ export default function TimelineScreen() {
   const [selectedDevices, setSelectedDevices] = useState<Set<string>>(new Set());
   const [selectedRoutes, setSelectedRoutes] = useState<Set<string>>(new Set());
   const [isFilterExpanded, setIsFilterExpanded] = useState(false);
+  const lineNames = useLineNames(state.lineIds);
 
   // アニメーション用の共有値
   const rotateValue = useSharedValue(0);
@@ -419,7 +421,7 @@ export default function TimelineScreen() {
               {/* Route ID Filter (only show if there are routes) */}
               {state.lineIds.length > 0 && (
                 <View className="mt-3">
-                  <Text className="text-sm text-muted mb-2">路線ID</Text>
+                  <Text className="text-sm text-muted mb-2">路線</Text>
                   <ScrollView
                     horizontal
                     showsHorizontalScrollIndicator={false}
@@ -471,7 +473,7 @@ export default function TimelineScreen() {
                             )}
                             numberOfLines={1}
                           >
-                            {lineId}
+                            {lineNames[lineId] ? <><Text style={{ fontWeight: "bold" }}>{lineNames[lineId]}</Text>({lineId})</> : lineId}
                           </Text>
                         </View>
                       </TouchableOpacity>
@@ -503,6 +505,7 @@ export default function TimelineScreen() {
       state.connectionStatus,
       state.deviceIds,
       state.lineIds,
+      lineNames,
       state.updates.length,
       searchQuery,
       selectedStates,

--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -3,6 +3,7 @@ import { View, Text } from "react-native";
 import type { LocationUpdate, MovingState, BatteryState } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 import { useColors } from "@/hooks/use-colors";
+import { useLineNames } from "@/hooks/use-line-names";
 
 interface LocationCardProps {
   update: LocationUpdate;
@@ -87,6 +88,8 @@ function formatBatteryState(state: BatteryState | number | null): string {
 
 export const LocationCard = memo(function LocationCard({ update }: LocationCardProps) {
   const colors = useColors();
+  const lineIds = update.line_id ? [update.line_id] : [];
+  const lineNames = useLineNames(lineIds);
   // stateConfigに存在しない値の場合はフォールバックを使用
   const stateConf = stateConfig[update.state as MovingState] || defaultStateConfig;
   const stateLabel = stateConf.label === "不明" && update.state ? String(update.state) : stateConf.label;
@@ -95,7 +98,7 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
   return (
     <View className="bg-surface rounded-xl p-4 border border-border">
       {/* Header: DateTime + Device + State Badge */}
-      <View className="flex-row justify-between items-center mb-2">
+      <View className="flex-row justify-between items-center mb-1">
         <View className="flex-row items-center">
           <Text className="text-foreground font-semibold text-base">
             🕐 {formatDate(update.timestamp)} {formatTimestamp(update.timestamp)}
@@ -116,11 +119,11 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
         </View>
       </View>
 
-      {/* Route ID */}
-      {update.line_id && (
-        <View className="flex-row items-center mb-2">
+      {/* Route Name */}
+      {update.line_id && lineNames[update.line_id] && (
+        <View className="flex-row items-center mb-1">
           <Text className="text-base mr-1">🚆</Text>
-          <Text className="text-foreground text-base">{update.line_id}</Text>
+          <Text className="text-foreground text-base">{lineNames[update.line_id]}</Text>
         </View>
       )}
 

--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -116,6 +116,14 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
         </View>
       </View>
 
+      {/* Route ID */}
+      {update.line_id && (
+        <View className="flex-row items-center mb-2">
+          <Text className="text-base mr-1">🚆</Text>
+          <Text className="text-foreground text-base">{update.line_id}</Text>
+        </View>
+      )}
+
       {/* Coordinates */}
       <View className="flex-row items-center mb-2">
         <Text className="text-base mr-1">📍</Text>

--- a/hooks/use-device-trajectory.ts
+++ b/hooks/use-device-trajectory.ts
@@ -15,6 +15,7 @@ export interface DeviceTrajectory {
   latestAccuracy: number | null | undefined;
   latestBatteryLevel: number | null;
   latestBatteryState: BatteryState | number | null;
+  latestLineId: string | null;
 }
 
 /**
@@ -67,6 +68,7 @@ export function useDeviceTrajectory(
         latestAccuracy: latestUpdate?.coords.accuracy ?? null,
         latestBatteryLevel: latestUpdate?.battery_level ?? null,
         latestBatteryState: latestUpdate?.battery_state ?? null,
+        latestLineId: latestUpdate?.line_id ?? null,
       });
     }
 

--- a/hooks/use-line-names.ts
+++ b/hooks/use-line-names.ts
@@ -1,0 +1,93 @@
+import { useEffect, useSyncExternalStore } from "react";
+import Constants from "expo-constants";
+
+let gqlUrl = Constants.expoConfig?.extra?.trainlcdGqlUrl || "";
+
+// モジュールレベルのキャッシュ（アプリ全体で共有）
+let cache: Record<string, string> = {};
+const fetchedIds = new Set<string>();
+const listeners = new Set<() => void>();
+
+function getSnapshot(): Record<string, string> {
+  return cache;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function notify() {
+  for (const l of listeners) l();
+}
+
+export function fetchLineNames(ids: string[]) {
+  const newIds = ids.filter((id) => !fetchedIds.has(id));
+  if (newIds.length === 0 || !gqlUrl) return;
+
+  for (const id of newIds) fetchedIds.add(id);
+
+  fetch(gqlUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query: `query Lines($lineIds: [Int!]!) { lines(lineIds: $lineIds) { id nameShort } }`,
+      variables: { lineIds: newIds.map(Number) },
+    }),
+  })
+    .then((res) => res.json())
+    .then((json) => {
+      const lines = json?.data?.lines as
+        | { id: number; nameShort: string }[]
+        | undefined;
+      if (!lines) return;
+      let updated = false;
+      const next = { ...cache };
+      for (const line of lines) {
+        if (line.nameShort) {
+          next[String(line.id)] = line.nameShort;
+          updated = true;
+        }
+      }
+      if (updated) {
+        cache = next;
+        notify();
+      }
+    })
+    .catch(() => {});
+}
+
+export function useLineNames(lineIds: string[]): Record<string, string> {
+  const lineNames = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  useEffect(() => {
+    fetchLineNames(lineIds);
+  }, [lineIds]);
+
+  return lineNames;
+}
+
+export function formatLineName(
+  lineId: string,
+  lineNames: Record<string, string>
+): string {
+  const name = lineNames[lineId];
+  return name ? `${name}(${lineId})` : lineId;
+}
+
+/** テスト用: キャッシュとfetchedIdsをリセット */
+export function _resetCache() {
+  cache = {};
+  fetchedIds.clear();
+  listeners.clear();
+}
+
+/** テスト用: 現在のキャッシュを返す */
+export function _getCache(): Record<string, string> {
+  return cache;
+}
+
+/** テスト用: GQL URLを上書き */
+export function _setGqlUrl(url: string) {
+  gqlUrl = url;
+}

--- a/lib/__tests__/location-store.test.ts
+++ b/lib/__tests__/location-store.test.ts
@@ -77,6 +77,7 @@ const initialState: LocationState = {
   error: null,
   messageCount: 0,
   deviceIds: [],
+  lineIds: [],
 };
 
 const createMockUpdate = (overrides: Partial<LocationUpdate> = {}): LocationUpdate => ({
@@ -91,6 +92,9 @@ const createMockUpdate = (overrides: Partial<LocationUpdate> = {}): LocationUpda
   state: "moving" as MovingState,
   timestamp: Date.now(),
   type: "location_update",
+  battery_level: 0.8,
+  battery_state: null,
+  line_id: null,
   ...overrides,
 });
 

--- a/lib/__tests__/use-line-names.test.ts
+++ b/lib/__tests__/use-line-names.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// expo-constantsをモック
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: { trainlcdGqlUrl: "" } } },
+}));
+
+// fetchをモック
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+import {
+  formatLineName,
+  fetchLineNames,
+  _resetCache,
+  _getCache,
+  _setGqlUrl,
+} from "../../hooks/use-line-names";
+
+beforeEach(() => {
+  _resetCache();
+  _setGqlUrl("https://gql-stg.trainlcd.app/");
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetchResponse(lines: { id: number; nameShort: string }[]) {
+  fetchMock.mockResolvedValueOnce({
+    json: () => Promise.resolve({ data: { lines } }),
+  });
+}
+
+describe("formatLineName", () => {
+  it("路線名がある場合は「路線名(ID)」形式で返す", () => {
+    const names = { "11302": "山手線" };
+    expect(formatLineName("11302", names)).toBe("山手線(11302)");
+  });
+
+  it("路線名がない場合はIDをそのまま返す", () => {
+    expect(formatLineName("11302", {})).toBe("11302");
+  });
+});
+
+describe("fetchLineNames", () => {
+  it("GraphQL APIにバッチクエリを送信する", async () => {
+    mockFetchResponse([
+      { id: 11302, nameShort: "山手線" },
+      { id: 24006, nameShort: "京王井の頭線" },
+    ]);
+
+    fetchLineNames(["11302", "24006"]);
+    await vi.waitFor(() => expect(_getCache()).toHaveProperty("11302"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.variables.lineIds).toEqual([11302, 24006]);
+    expect(_getCache()).toEqual({
+      "11302": "山手線",
+      "24006": "京王井の頭線",
+    });
+  });
+
+  it("取得済みIDはスキップする（キャッシュ済み）", async () => {
+    mockFetchResponse([{ id: 11302, nameShort: "山手線" }]);
+    fetchLineNames(["11302"]);
+    await vi.waitFor(() => expect(_getCache()).toHaveProperty("11302"));
+
+    fetchLineNames(["11302"]);
+    // 2回目のfetchは呼ばれない
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("新規IDのみを差分リクエストする", async () => {
+    mockFetchResponse([{ id: 11302, nameShort: "山手線" }]);
+    fetchLineNames(["11302"]);
+    await vi.waitFor(() => expect(_getCache()).toHaveProperty("11302"));
+
+    mockFetchResponse([{ id: 24006, nameShort: "京王井の頭線" }]);
+    fetchLineNames(["11302", "24006"]);
+    await vi.waitFor(() => expect(_getCache()).toHaveProperty("24006"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(secondBody.variables.lineIds).toEqual([24006]);
+  });
+
+  it("GQL URLが空の場合はfetchしない", () => {
+    _setGqlUrl("");
+    fetchLineNames(["11302"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("空のID配列の場合はfetchしない", () => {
+    fetchLineNames([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetchエラー時はキャッシュが変更されない", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("Network error"));
+    fetchLineNames(["99999"]);
+
+    // エラー処理を待つ
+    await new Promise((r) => setTimeout(r, 10));
+    expect(_getCache()).toEqual({});
+  });
+
+  it("nameShortが空のlineはキャッシュに入れない", async () => {
+    mockFetchResponse([
+      { id: 11302, nameShort: "山手線" },
+      { id: 99999, nameShort: "" },
+    ]);
+
+    fetchLineNames(["11302", "99999"]);
+    await vi.waitFor(() => expect(_getCache()).toHaveProperty("11302"));
+
+    expect(_getCache()).toEqual({ "11302": "山手線" });
+    expect(_getCache()).not.toHaveProperty("99999");
+  });
+
+  it("APIレスポンスのlinesがundefinedの場合はキャッシュが変更されない", async () => {
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve({ data: {} }),
+    });
+
+    fetchLineNames(["11302"]);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(_getCache()).toEqual({});
+  });
+
+  it("subscribeでリスナーが通知される", async () => {
+    const { _resetCache: _, ...mod } = await import("../../hooks/use-line-names");
+
+    _resetCache();
+    const listener = vi.fn();
+
+    // subscribe/getSnapshotを直接テストするためにモジュールのsubscribeを利用
+    // fetchLineNamesの内部でnotifyが呼ばれることを間接的にテスト
+    mockFetchResponse([{ id: 11302, nameShort: "山手線" }]);
+    fetchLineNames(["11302"]);
+    await vi.waitFor(() => expect(_getCache()).toHaveProperty("11302"));
+    // キャッシュが更新されたことで正しい値が入っている
+    expect(_getCache()["11302"]).toBe("山手線");
+  });
+});

--- a/lib/location-store.tsx
+++ b/lib/location-store.tsx
@@ -46,6 +46,7 @@ const initialState: LocationState = {
   error: null,
   messageCount: 0,
   deviceIds: [],
+  lineIds: [],
 };
 
 function locationReducer(state: LocationState, action: LocationAction): LocationState {
@@ -59,11 +60,16 @@ function locationReducer(state: LocationState, action: LocationAction): Location
       const deviceIds = state.deviceIds.includes(update.device)
         ? state.deviceIds
         : [...state.deviceIds, update.device];
+      const lineIds =
+        update.line_id && !state.lineIds.includes(update.line_id)
+          ? [...state.lineIds, update.line_id]
+          : state.lineIds;
       return {
         ...state,
         updates: newUpdates,
         messageCount: state.messageCount + 1,
         deviceIds,
+        lineIds,
       };
     }
     case "ADD_LOG": {
@@ -85,7 +91,7 @@ function locationReducer(state: LocationState, action: LocationAction): Location
     case "SET_ERROR":
       return { ...state, error: action.payload };
     case "CLEAR_UPDATES":
-      return { ...state, updates: [], logs: [], messageCount: 0, deviceIds: [] };
+      return { ...state, updates: [], logs: [], messageCount: 0, deviceIds: [], lineIds: [] };
     case "LOAD_INITIAL_STATE":
       return { ...state, ...action.payload };
     default:

--- a/lib/types/location.ts
+++ b/lib/types/location.ts
@@ -34,6 +34,7 @@ export interface LocationUpdate {
   type: "location_update";
   battery_level: number;
   battery_state: BatteryState | null;
+  line_id: string | null;
 }
 
 /**
@@ -101,6 +102,7 @@ export interface LocationState {
   error: string | null;
   messageCount: number;
   deviceIds: string[];
+  lineIds: string[];
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -16107,23 +16107,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tar": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
@@ -16470,7 +16453,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16487,7 +16469,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16504,7 +16485,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16521,7 +16501,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16538,7 +16517,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16555,7 +16533,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16572,7 +16549,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16589,7 +16565,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16606,7 +16581,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16623,7 +16597,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16640,7 +16613,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16657,7 +16629,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16674,7 +16645,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16691,7 +16661,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16708,7 +16677,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16725,7 +16693,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16742,7 +16709,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16759,7 +16725,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16776,7 +16741,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16793,7 +16757,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16810,7 +16773,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16827,7 +16789,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16844,7 +16805,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16861,7 +16821,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16878,7 +16837,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16895,7 +16853,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
- LocationUpdate型にline_idフィールドを追加
- LocationStateにlineIds配列を追加し、受信時に自動収集
- タイムライン: 路線IDによる絞り込みフィルター追加（テキスト検索にも対応）
- マップ: 路線IDで軌跡データをフィルタリング可能に
- LocationCardにline_idの表示を追加

https://claude.ai/code/session_01Ro6oDyNq7sLWArLvCZ3YEk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ルート（路線）IDによるフィルタリングをマップとタイムラインに追加
  * ルート名表示（カード・コールアウト・軌跡に反映）

* **改善**
  * デバイスフィルターとルートフィルターを同時に利用可能に拡張
  * フィルター状況を示す「適用中」バッジとフィルターUIの強化

* **テスト**
  * ルート名取得とキャッシュ挙動に関するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->