### PR TITLE
feat: マップのストローク色にGraphQLのラインカラーを使用

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -25,7 +25,7 @@ import {
   useDeviceTrajectory,
   getAllCoordinates,
 } from "@/hooks/use-device-trajectory";
-import { getDeviceColor } from "@/constants/map-colors";
+import { MAP_TRAJECTORY_COLORS } from "@/constants/map-colors";
 import type { MovingState } from "@/lib/types/location";
 import { useLineNames, useLineColors } from "@/hooks/use-line-names";
 
@@ -326,7 +326,6 @@ export default function MapScreen() {
                       </View>
                     </TouchableOpacity>
                     {state.deviceIds.map((device) => {
-                      const deviceColor = getDeviceColor(device, state.deviceIds);
                       const isSelected = selectedDevices.has(device);
                       return (
                         <TouchableOpacity
@@ -336,18 +335,18 @@ export default function MapScreen() {
                           style={styles.filterButton}
                         >
                           <View
-                            className="px-3 py-2 rounded-full"
-                            style={{
-                              backgroundColor: isSelected ? deviceColor : "transparent",
-                              borderWidth: 1,
-                              borderColor: deviceColor,
-                            }}
+                            className={cn(
+                              "px-3 py-2 rounded-full border",
+                              isSelected
+                                ? "bg-primary border-primary"
+                                : "bg-background border-border"
+                            )}
                           >
                             <Text
-                              className="text-sm font-medium"
-                              style={{
-                                color: isSelected ? "#FFFFFF" : deviceColor,
-                              }}
+                              className={cn(
+                                "text-sm font-medium",
+                                isSelected ? "text-white" : "text-foreground"
+                              )}
                             >
                               {device}
                             </Text>
@@ -471,7 +470,7 @@ export default function MapScreen() {
                         <Polyline
                           key={`${trajectory.deviceId}-${i}`}
                           coordinates={segment.coordinates}
-                          strokeColor={(segment.lineId && lineColors[segment.lineId]) || getDeviceColor(trajectory.deviceId, state.deviceIds)}
+                          strokeColor={(segment.lineId && lineColors[segment.lineId]) || MAP_TRAJECTORY_COLORS[0]}
                           strokeWidth={4}
                         />
                       )
@@ -485,7 +484,7 @@ export default function MapScreen() {
                         <View
                           style={[
                             styles.startMarker,
-                            { borderColor: (trajectory.segments[0]?.lineId && lineColors[trajectory.segments[0].lineId]) || getDeviceColor(trajectory.deviceId, state.deviceIds) },
+                            { borderColor: (trajectory.segments[0]?.lineId && lineColors[trajectory.segments[0].lineId]) || MAP_TRAJECTORY_COLORS[0] },
                           ]}
                         />
                       </Marker>
@@ -509,7 +508,7 @@ export default function MapScreen() {
                             }
                           }}
                           coordinate={trajectory.latestPosition}
-                          pinColor={(trajectory.latestLineId && lineColors[trajectory.latestLineId]) || getDeviceColor(trajectory.deviceId, state.deviceIds)}
+                          pinColor={(trajectory.latestLineId && lineColors[trajectory.latestLineId]) || MAP_TRAJECTORY_COLORS[0]}
                           stopPropagation
                           onPress={() => handleMarkerPress(trajectory.deviceId)}
                           onCalloutPress={() => handleCalloutPress(trajectory.deviceId)}

--- a/constants/map-colors.ts
+++ b/constants/map-colors.ts
@@ -13,15 +13,3 @@ export const MAP_TRAJECTORY_COLORS = [
   "#BB8FCE", // 紫
   "#85C1E9", // スカイブルー
 ] as const;
-
-/**
- * デバイスIDからPolylineの色を取得
- * デバイスIDのハッシュ値を使って色を決定する
- */
-export function getDeviceColor(deviceId: string, deviceIds: string[]): string {
-  const index = deviceIds.indexOf(deviceId);
-  if (index === -1) {
-    return MAP_TRAJECTORY_COLORS[0];
-  }
-  return MAP_TRAJECTORY_COLORS[index % MAP_TRAJECTORY_COLORS.length];
-}

--- a/hooks/use-line-names.ts
+++ b/hooks/use-line-names.ts
@@ -5,11 +5,16 @@ let gqlUrl = Constants.expoConfig?.extra?.trainlcdGqlUrl || "";
 
 // モジュールレベルのキャッシュ（アプリ全体で共有）
 let cache: Record<string, string> = {};
+let colorCache: Record<string, string> = {};
 const fetchedIds = new Set<string>();
 const listeners = new Set<() => void>();
 
 function getSnapshot(): Record<string, string> {
   return cache;
+}
+
+function getColorSnapshot(): Record<string, string> {
+  return colorCache;
 }
 
 function subscribe(listener: () => void): () => void {
@@ -31,26 +36,32 @@ export function fetchLineNames(ids: string[]) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      query: `query Lines($lineIds: [Int!]!) { lines(lineIds: $lineIds) { id nameShort } }`,
+      query: `query Lines($lineIds: [Int!]!) { lines(lineIds: $lineIds) { id nameShort color } }`,
       variables: { lineIds: newIds.map(Number) },
     }),
   })
     .then((res) => res.json())
     .then((json) => {
       const lines = json?.data?.lines as
-        | { id: number; nameShort: string }[]
+        | { id: number; nameShort: string; color: string | null }[]
         | undefined;
       if (!lines) return;
       let updated = false;
-      const next = { ...cache };
+      const nextNames = { ...cache };
+      const nextColors = { ...colorCache };
       for (const line of lines) {
         if (line.nameShort) {
-          next[String(line.id)] = line.nameShort;
+          nextNames[String(line.id)] = line.nameShort;
+          updated = true;
+        }
+        if (line.color) {
+          nextColors[String(line.id)] = line.color.startsWith("#") ? line.color : `#${line.color}`;
           updated = true;
         }
       }
       if (updated) {
-        cache = next;
+        cache = nextNames;
+        colorCache = nextColors;
         notify();
       }
     })
@@ -67,6 +78,16 @@ export function useLineNames(lineIds: string[]): Record<string, string> {
   return lineNames;
 }
 
+export function useLineColors(lineIds: string[]): Record<string, string> {
+  const lineColors = useSyncExternalStore(subscribe, getColorSnapshot, getColorSnapshot);
+
+  useEffect(() => {
+    fetchLineNames(lineIds);
+  }, [lineIds]);
+
+  return lineColors;
+}
+
 export function formatLineName(
   lineId: string,
   lineNames: Record<string, string>
@@ -78,6 +99,7 @@ export function formatLineName(
 /** テスト用: キャッシュとfetchedIdsをリセット */
 export function _resetCache() {
   cache = {};
+  colorCache = {};
   fetchedIds.clear();
   listeners.clear();
 }
@@ -85,6 +107,11 @@ export function _resetCache() {
 /** テスト用: 現在のキャッシュを返す */
 export function _getCache(): Record<string, string> {
   return cache;
+}
+
+/** テスト用: 現在のカラーキャッシュを返す */
+export function _getColorCache(): Record<string, string> {
+  return colorCache;
 }
 
 /** テスト用: GQL URLを上書き */


### PR DESCRIPTION
- GraphQLクエリにcolorフィールドを追加し、路線カラーを取得
- Polylineを路線セグメントごとに分割して各路線の色で描画
- 路線フィルターボタンにもラインカラーを適用
- 軌跡の始点に小さい丸マーカーを追加

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * マップで線ごとの色指定に対応し、線フィルター、ポリライン、開始/最新マーカーが各路線色で表示されます。
  * 軌跡をセグメント単位で色分けして描画し、視認性が向上しました。
* **テスト**
  * 線色キャッシュの挙動を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->