### PR TITLE
Add retry logic and improve test timing for fetchLineNames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 node_modules/
+package-lock.json
 
 # Expo
 .expo/

--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { View, Text } from "react-native";
 import type { LocationUpdate, MovingState, BatteryState } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
@@ -88,7 +88,7 @@ function formatBatteryState(state: BatteryState | number | null): string {
 
 export const LocationCard = memo(function LocationCard({ update }: LocationCardProps) {
   const colors = useColors();
-  const lineIds = update.line_id ? [update.line_id] : [];
+  const lineIds = useMemo(() => (update.line_id ? [update.line_id] : []), [update.line_id]);
   const lineNames = useLineNames(lineIds);
   // stateConfigに存在しない値の場合はフォールバックを使用
   const stateConf = stateConfig[update.state as MovingState] || defaultStateConfig;

--- a/hooks/use-line-names.ts
+++ b/hooks/use-line-names.ts
@@ -92,9 +92,12 @@ export function fetchLineNames(ids: string[], _retryCount = 0) {
 export function useLineNames(lineIds: string[]): Record<string, string> {
   const lineNames = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
+  // lineIdsの中身が同じなら再取得しないよう、値ベースで比較
+  const lineIdsKey = lineIds.join(",");
   useEffect(() => {
     fetchLineNames(lineIds);
-  }, [lineIds]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lineIdsKey]);
 
   return lineNames;
 }
@@ -102,9 +105,11 @@ export function useLineNames(lineIds: string[]): Record<string, string> {
 export function useLineColors(lineIds: string[]): Record<string, string> {
   const lineColors = useSyncExternalStore(subscribe, getColorSnapshot, getColorSnapshot);
 
+  const lineIdsKey = lineIds.join(",");
   useEffect(() => {
     fetchLineNames(lineIds);
-  }, [lineIds]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lineIdsKey]);
 
   return lineColors;
 }


### PR DESCRIPTION
## Summary
Implemented exponential backoff retry logic for failed line name fetches and refactored tests to use fake timers for more reliable async testing.

## Key Changes

### Source Code (`hooks/use-line-names.ts`)
- **Retry mechanism**: Added exponential backoff retry logic with up to 3 retries at 2s, 4s, and 8s intervals
- **Request deduplication**: Introduced `pendingIds` Set to prevent duplicate requests for IDs currently being fetched
- **State tracking**: Separated `fetchedIds` into `resolvedIds` (successful fetches) and `pendingIds` (in-flight requests)
- **Error handling**: Modified error handling to treat missing `lines` data in responses as retriable errors
- **Cleanup**: Properly remove IDs from `pendingIds` on both success and failure

### Tests (`lib/__tests__/use-line-names.test.ts`)
- **Fake timers**: Enabled `vi.useFakeTimers()` in `beforeEach` and `vi.useRealTimers()` in `afterEach` for deterministic async testing
- **Helper function**: Added `flushPromises()` utility to advance microtask queue instead of using `vi.waitFor()`
- **New test cases**: 
  - Retry behavior on fetch failures
  - Max retry limit enforcement
  - Retry reset after all retries exhausted
  - Duplicate request prevention for in-flight requests
  - Retry behavior when API response lacks `lines` data
- **Test updates**: Replaced all `vi.waitFor()` calls with `flushPromises()` for consistency and replaced `setTimeout` waits with timer advancement

### Configuration
- Added `package-lock.json` to `.gitignore`

## Implementation Details
- Retries use exponential backoff delays: 2s → 4s → 8s
- IDs are only considered "resolved" after successful fetch, allowing retry if initial fetch fails
- Pending requests are tracked separately to avoid concurrent requests for the same ID
- Both network errors and missing response data trigger retry logic

https://claude.ai/code/session_01AeztrVJGigrhtYXRwbWx3r

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ネットワークエラー時の再試行を強化しました（指数バックオフで最大3回まで自動再試行）。
  * 同一データの重複リクエストを抑制し、無駄な問い合わせを減らしました。
  * 一部の計算結果をメモ化して再レンダリング時の負荷を低減しました。

* **テスト**
  * フェイクタイマー等を用いた再試行挙動のテストを拡充しました。

* **その他**
  * 開発用設定（依存管理の無視設定）を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->