### PR TITLE
「現在地に戻る」を「全体を表示」に文言変更

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -156,7 +156,7 @@ export default function MapScreen() {
     }
   }, []);
 
-  // 現在地に戻るボタン
+  // 全体を表示ボタン
   const handleReturnToCurrentLocation = useCallback(() => {
     if (!mapRef.current) return;
     if (Platform.OS !== "web") {
@@ -551,7 +551,7 @@ export default function MapScreen() {
                   onPress={handleReturnToCurrentLocation}
                   activeOpacity={0.8}
                 >
-                  <Text style={styles.returnButtonText}>現在地に戻る</Text>
+                  <Text style={styles.returnButtonText}>全体を表示</Text>
                 </TouchableOpacity>
               )}
             </View>


### PR DESCRIPTION
https://claude.ai/code/session_01KxCwtnzufNf2yMAHPNFMkN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * マップ画面の戻るボタンのラベルテキストを更新しました。ボタンの表示が「現在地に戻る」から「全体を表示」に変更されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->