### PR TITLE
feat: マップ吹き出しに経過時間表示を追加

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, useMemo, Fragment } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo, useReducer, Fragment } from "react";
 import {
   Text,
   View,
@@ -73,11 +73,11 @@ function CalloutContent({
   latestAccuracy: number | null | undefined;
   latestBatteryLevel: number | null;
 }) {
-  const [, setTick] = useState(0);
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
   useEffect(() => {
     if (timestamp == null) return;
-    const id = setInterval(() => setTick((t) => t + 1), TIME_AGO_INTERVAL_MS);
+    const id = setInterval(forceUpdate, TIME_AGO_INTERVAL_MS);
     return () => clearInterval(id);
   }, [timestamp]);
 

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -47,6 +47,68 @@ if (Platform.OS !== "web") {
 type MapViewRef = import("react-native-maps").default;
 type MapMarkerRef = { showCallout: () => void; hideCallout: () => void };
 
+// 吹き出し内コンテンツ（経過時間をライブ更新するため独立コンポーネント化）
+const TIME_AGO_INTERVAL_MS = 10_000;
+
+function CalloutContent({
+  deviceId,
+  stateLabel,
+  stateConf,
+  borderColor,
+  timestamp,
+  lineId,
+  lineNames,
+  latestSpeed,
+  latestAccuracy,
+  latestBatteryLevel,
+}: {
+  deviceId: string;
+  stateLabel: string;
+  stateConf: { bgClass: string; textClass: string };
+  borderColor: string;
+  timestamp: number | null;
+  lineId: string | null;
+  lineNames: Record<string, string>;
+  latestSpeed: number | null | undefined;
+  latestAccuracy: number | null | undefined;
+  latestBatteryLevel: number | null;
+}) {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (timestamp == null) return;
+    const id = setInterval(() => setTick((t) => t + 1), TIME_AGO_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [timestamp]);
+
+  return (
+    <View style={styles.calloutContainer}>
+      <View style={styles.calloutHeader}>
+        <Text style={styles.calloutTitle}>{deviceId}</Text>
+        <View
+          className={cn("px-2 py-0.5 rounded-full", stateConf.bgClass)}
+          style={{ borderWidth: 1, borderColor }}
+        >
+          <Text className={cn("text-xs font-medium", stateConf.textClass)}>
+            {stateLabel}
+          </Text>
+        </View>
+      </View>
+      <Text style={styles.calloutDescription}>
+        最新位置{timestamp != null ? `・${formatTimeAgo(timestamp)}` : ""}
+      </Text>
+      {lineId && lineNames[lineId] && (
+        <Text style={styles.calloutLineName}>🚆 {lineNames[lineId]}</Text>
+      )}
+      <View style={styles.calloutMetrics}>
+        <Text style={styles.calloutMetricText}>🏎️ {formatSpeed(latestSpeed)}</Text>
+        <Text style={styles.calloutMetricText}>🎯 {formatAccuracy(latestAccuracy)}</Text>
+        <Text style={styles.calloutMetricText}>🔋 {latestBatteryLevel != null ? formatBatteryLevel(latestBatteryLevel) : "-"}</Text>
+      </View>
+    </View>
+  );
+}
+
 // アコーディオンコンテンツの最大高さ（アニメーション用）
 const ACCORDION_MAX_HEIGHT_BASE = 100;
 const ACCORDION_MAX_HEIGHT_WITH_ROUTES = 200;
@@ -515,28 +577,18 @@ export default function MapScreen() {
                         >
                           {Callout && (
                             <Callout tooltip={false}>
-                              <View style={styles.calloutContainer}>
-                                <View style={styles.calloutHeader}>
-                                  <Text style={styles.calloutTitle}>{trajectory.deviceId}</Text>
-                                  <View
-                                    className={cn("px-2 py-0.5 rounded-full", stateConf.bgClass)}
-                                    style={{ borderWidth: 1, borderColor }}
-                                  >
-                                    <Text className={cn("text-xs font-medium", stateConf.textClass)}>
-                                      {stateLabel}
-                                    </Text>
-                                  </View>
-                                </View>
-                                <Text style={styles.calloutDescription}>最新位置{trajectory.latestTimestamp != null ? `・${formatTimeAgo(trajectory.latestTimestamp)}` : ""}</Text>
-                                {trajectory.latestLineId && lineNames[trajectory.latestLineId] && (
-                                  <Text style={styles.calloutLineName}>🚆 {lineNames[trajectory.latestLineId]}</Text>
-                                )}
-                                <View style={styles.calloutMetrics}>
-                                  <Text style={styles.calloutMetricText}>🏎️ {formatSpeed(trajectory.latestSpeed)}</Text>
-                                  <Text style={styles.calloutMetricText}>🎯 {formatAccuracy(trajectory.latestAccuracy)}</Text>
-                                  <Text style={styles.calloutMetricText}>🔋 {trajectory.latestBatteryLevel != null ? formatBatteryLevel(trajectory.latestBatteryLevel) : "-"}</Text>
-                                </View>
-                              </View>
+                              <CalloutContent
+                                deviceId={trajectory.deviceId}
+                                stateLabel={stateLabel}
+                                stateConf={stateConf}
+                                borderColor={borderColor}
+                                timestamp={trajectory.latestTimestamp}
+                                lineId={trajectory.latestLineId}
+                                lineNames={lineNames}
+                                latestSpeed={trajectory.latestSpeed}
+                                latestAccuracy={trajectory.latestAccuracy}
+                                latestBatteryLevel={trajectory.latestBatteryLevel}
+                              />
                             </Callout>
                           )}
                         </Marker>

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -17,7 +17,7 @@ import Animated, {
 
 import { ScreenContainer } from "@/components/screen-container";
 import { ConnectionStatusBadge } from "@/components/connection-status";
-import { stateConfig, defaultStateConfig, formatSpeed, formatAccuracy, formatBatteryLevel } from "@/components/location-card";
+import { stateConfig, defaultStateConfig, formatSpeed, formatAccuracy, formatBatteryLevel, formatTimeAgo } from "@/components/location-card";
 import { useLocation } from "@/lib/location-store";
 import { useColors } from "@/hooks/use-colors";
 import { cn } from "@/lib/utils";
@@ -527,7 +527,7 @@ export default function MapScreen() {
                                     </Text>
                                   </View>
                                 </View>
-                                <Text style={styles.calloutDescription}>最新位置</Text>
+                                <Text style={styles.calloutDescription}>最新位置{trajectory.latestTimestamp != null ? `・${formatTimeAgo(trajectory.latestTimestamp)}` : ""}</Text>
                                 {trajectory.latestLineId && lineNames[trajectory.latestLineId] && (
                                   <Text style={styles.calloutLineName}>🚆 {lineNames[trajectory.latestLineId]}</Text>
                                 )}

--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -62,6 +62,34 @@ export function formatBatteryLevel(level: number): string {
   return `${Math.round(level * 100)}%`;
 }
 
+export function formatTimeAgo(timestamp: number): string {
+  const now = Date.now();
+  const diffMs = now - timestamp;
+  const diffSec = Math.floor(diffMs / 1000);
+
+  if (diffSec < 60) {
+    return `${diffSec}秒前`;
+  }
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) {
+    return `${diffMin}分前`;
+  }
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) {
+    return `${diffHour}時間前`;
+  }
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffDay < 30) {
+    return `${diffDay}日前`;
+  }
+  const diffMonth = Math.floor(diffDay / 30);
+  if (diffMonth < 12) {
+    return `${diffMonth}ヶ月前`;
+  }
+  const diffYear = Math.floor(diffMonth / 12);
+  return `${diffYear}年前`;
+}
+
 const batteryStateLabels: Record<BatteryState, string> = {
   charging: "充電中",
   unplugged: "未接続",

--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -65,6 +65,9 @@ export function formatBatteryLevel(level: number): string {
 export function formatTimeAgo(timestamp: number): string {
   const now = Date.now();
   const diffMs = now - timestamp;
+  if (diffMs <= 0) {
+    return "たった今";
+  }
   const diffSec = Math.floor(diffMs / 1000);
 
   if (diffSec < 60) {

--- a/hooks/use-device-trajectory.ts
+++ b/hooks/use-device-trajectory.ts
@@ -22,6 +22,7 @@ export interface DeviceTrajectory {
   latestBatteryLevel: number | null;
   latestBatteryState: BatteryState | number | null;
   latestLineId: string | null;
+  latestTimestamp: number | null;
 }
 
 /**
@@ -95,6 +96,7 @@ export function useDeviceTrajectory(
         latestBatteryLevel: latestUpdate?.battery_level ?? null,
         latestBatteryState: latestUpdate?.battery_state ?? null,
         latestLineId: latestUpdate?.line_id ?? null,
+        latestTimestamp: latestUpdate?.timestamp ?? null,
       });
     }
 


### PR DESCRIPTION
最新位置の文言の後に中黒（・）をセパレータとして
「〜秒前」「〜分前」「〜時間前」「〜日前」「〜ヶ月前」「〜年前」
の動的な経過時間テキストを表示するように変更

https://claude.ai/code/session_015En85PtwwQhrGDwZZGURDM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 地図のコールアウト表示を新しいコンポーネント化で改善し、表示内容（路線名、速度、精度、電池等）が整理されました。
  * コールアウトの選択・解除がマップ操作に連動して扱いやすくなりました（アクティブなコールアウト管理）。
  * コールアウト内の時刻表記を日本語の相対表現（例：「5分前」）で表示し、約10秒間隔で自動更新します。
  * 各軌跡データに最新更新時刻が追加され、表示の精度が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->