### PR TITLE
fix: 吹き出し内のNativeWind classNameをstyleに変換しレイアウトずれを修正

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -88,10 +88,12 @@ function CalloutContent({
       <View style={styles.calloutHeader}>
         <Text style={styles.calloutTitle}>{deviceId}</Text>
         <View
-          className={cn("px-2 py-0.5 rounded-full", stateConf.bgClass)}
-          style={{ borderWidth: 1, borderColor }}
+          style={[
+            styles.calloutBadge,
+            { borderColor, backgroundColor: borderColor + "33" },
+          ]}
         >
-          <Text className={cn("text-xs font-medium", stateConf.textClass)}>
+          <Text style={[styles.calloutBadgeText, { color: borderColor }]}>
             {stateLabel}
           </Text>
         </View>
@@ -682,6 +684,16 @@ const styles = StyleSheet.create({
   calloutTitle: {
     fontSize: 14,
     fontWeight: "600",
+  },
+  calloutBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 9999,
+    borderWidth: 1,
+  },
+  calloutBadgeText: {
+    fontSize: 12,
+    fontWeight: "500",
   },
   calloutDescription: {
     fontSize: 12,


### PR DESCRIPTION
react-native-mapsのCallout内でNativeWindのclassNameを使用すると、
スタイルが非同期に適用されるため初回レンダリング時にレイアウトが
ずれる問題を修正。状態バッジのスタイルをStyleSheetに移行し、
初回レンダリングから正しいサイズで表示されるようにした。

https://claude.ai/code/session_013ZFH74Dyo4ghzS2KwvZfjX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * マップ表示のバッジコンポーネントのスタイル定義を更新しました。バッジの外観とテキスト表示がより一貫した方法で管理されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->