### PR TITLE
吹き出しのステータスタグから背景色を削除

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -90,7 +90,7 @@ function CalloutContent({
         <View
           style={[
             styles.calloutBadge,
-            { borderColor, backgroundColor: borderColor + "33" },
+            { borderColor },
           ]}
         >
           <Text style={[styles.calloutBadgeText, { color: borderColor }]}>


### PR DESCRIPTION
他の画面のタグと統一するため、マップ吹き出し内のステータスバッジから
背景色（borderColor + "33"）を取り除く。

https://claude.ai/code/session_018fi5etDTXvuQFwnMwSzYVn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * マップ表示のバッジビジュアルを調整しました。半透明の背景効果を削除し、より洗練された表示になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->