### PR TITLE
Add line color support to timeline route filters

### DIFF
--- a/app/(tabs)/timeline.tsx
+++ b/app/(tabs)/timeline.tsx
@@ -25,7 +25,7 @@ import { useLocation } from "@/lib/location-store";
 import type { LocationUpdate, MovingState } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 import { useColors } from "@/hooks/use-colors";
-import { useLineNames } from "@/hooks/use-line-names";
+import { useLineNames, useLineColors } from "@/hooks/use-line-names";
 
 // 状態フィルターオプションの定義
 const MOVING_STATES: { value: MovingState; label: string }[] = [
@@ -50,6 +50,7 @@ export default function TimelineScreen() {
   const [selectedRoutes, setSelectedRoutes] = useState<Set<string>>(new Set());
   const [isFilterExpanded, setIsFilterExpanded] = useState(false);
   const lineNames = useLineNames(state.lineIds);
+  const lineColors = useLineColors(state.lineIds);
 
   // アニメーション用の共有値
   const rotateValue = useSharedValue(0);
@@ -451,33 +452,42 @@ export default function TimelineScreen() {
                         </Text>
                       </View>
                     </TouchableOpacity>
-                    {state.lineIds.map((lineId) => (
-                      <TouchableOpacity
-                        key={lineId}
-                        onPress={() => handleRouteSelect(lineId)}
-                        activeOpacity={0.7}
-                        style={styles.filterButton}
-                      >
-                        <View
-                          className={cn(
-                            "px-3 py-2 rounded-full border",
-                            selectedRoutes.has(lineId)
-                              ? "bg-primary border-primary"
-                              : "bg-background border-border"
-                          )}
+                    {state.lineIds.map((lineId) => {
+                      const lineColor = lineColors[lineId];
+                      const isSelected = selectedRoutes.has(lineId);
+                      return (
+                        <TouchableOpacity
+                          key={lineId}
+                          onPress={() => handleRouteSelect(lineId)}
+                          activeOpacity={0.7}
+                          style={styles.filterButton}
                         >
-                          <Text
+                          <View
                             className={cn(
-                              "text-sm font-medium",
-                              selectedRoutes.has(lineId) ? "text-white" : "text-foreground"
+                              "px-3 py-2 rounded-full",
+                              !lineColor && "border",
+                              !lineColor && (isSelected ? "bg-primary border-primary" : "bg-background border-border")
                             )}
-                            numberOfLines={1}
+                            style={lineColor ? {
+                              backgroundColor: isSelected ? lineColor : "transparent",
+                              borderWidth: 1,
+                              borderColor: lineColor,
+                            } : undefined}
                           >
-                            {lineNames[lineId] ? <><Text style={{ fontWeight: "bold" }}>{lineNames[lineId]}</Text>({lineId})</> : lineId}
-                          </Text>
-                        </View>
-                      </TouchableOpacity>
-                    ))}
+                            <Text
+                              className={cn(
+                                "text-sm font-medium",
+                                !lineColor && (isSelected ? "text-white" : "text-foreground")
+                              )}
+                              style={lineColor ? { color: isSelected ? "#FFFFFF" : lineColor } : undefined}
+                              numberOfLines={1}
+                            >
+                              {lineNames[lineId] ? <><Text style={{ fontWeight: "bold" }}>{lineNames[lineId]}</Text>({lineId})</> : lineId}
+                            </Text>
+                          </View>
+                        </TouchableOpacity>
+                      );
+                    })}
                   </ScrollView>
                 </View>
               )}
@@ -506,6 +516,7 @@ export default function TimelineScreen() {
       state.deviceIds,
       state.lineIds,
       lineNames,
+      lineColors,
       state.updates.length,
       searchQuery,
       selectedStates,


### PR DESCRIPTION
## Summary
Enhanced the timeline route filter buttons to display line-specific colors when available, improving visual distinction between different transit lines.

## Key Changes
- Imported `useLineColors` hook from `use-line-names` module
- Added `lineColors` state by calling `useLineColors(state.lineIds)` 
- Refactored route filter button rendering to:
  - Extract line color and selection state into variables for clarity
  - Apply dynamic styling based on line color availability
  - Use line color for button background when selected and border color always
  - Adjust text color to white when button is selected with a line color, otherwise use the line color itself
  - Maintain fallback styling for routes without assigned colors (primary/background theme colors)
- Updated dependency array in useEffect to include `lineColors`

## Implementation Details
The filter buttons now support two styling modes:
1. **With line color**: Colored border, transparent/colored background on selection, dynamic text color
2. **Without line color**: Original theme-based styling with primary/background colors

This provides better visual feedback and makes it easier for users to identify and filter by specific transit lines.

https://claude.ai/code/session_01QJE4R16zQtshQtHkCCPRXb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * タイムラインの行フィルターにカラーコーディング機能を追加しました。各線路に対応する色がフィルターボタンに表示されるようになり、より視覚的で直感的な操作が可能になりました。色の変更にも動的に対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->