### PR TITLE
fix: タイムライン・ログ画面のスクロール安定化とヘッダー固定

### DIFF
--- a/app/(tabs)/logs.tsx
+++ b/app/(tabs)/logs.tsx
@@ -244,9 +244,7 @@ export default function LogsScreen() {
     []
   );
 
-  const keyExtractor = useCallback((item: LogData, index: number) => {
-    return item.id || `log-${item.timestamp}-${index}`;
-  }, []);
+  const keyExtractor = useCallback((item: LogData) => item.id, []);
 
   const ListEmpty = useMemo(
     () => (

--- a/app/(tabs)/logs.tsx
+++ b/app/(tabs)/logs.tsx
@@ -248,9 +248,29 @@ export default function LogsScreen() {
     return item.id || `log-${item.timestamp}-${index}`;
   }, []);
 
-  const ListHeader = useMemo(
+  const ListEmpty = useMemo(
     () => (
-      <View className="mb-4">
+      <View className="flex-1 items-center justify-center py-20">
+        <Text style={{ fontSize: 64, lineHeight: 80 }} className="mb-4">📝</Text>
+        <Text className="text-lg font-semibold text-foreground mb-2">
+          {hasActiveFilter
+            ? "条件に一致するログがありません"
+            : "ログがありません"}
+        </Text>
+        <Text className="text-sm text-muted text-center px-8">
+          {hasActiveFilter
+            ? "フィルター条件を変更してください"
+            : "WebSocketに接続してログデータを受信してください"}
+        </Text>
+      </View>
+    ),
+    [hasActiveFilter]
+  );
+
+  return (
+    <ScreenContainer>
+      {/* ヘッダー部分（スクロールに追従して固定表示） */}
+      <View style={styles.stickyHeader}>
         {/* Header with status */}
         <View className="flex-row justify-between items-center mb-4">
           <Text className="text-2xl font-bold text-foreground">ログ</Text>
@@ -510,58 +530,18 @@ export default function LogsScreen() {
           )}
         </View>
       </View>
-    ),
-    [
-      state.connectionStatus,
-      state.logs.length,
-      searchQuery,
-      selectedTypes,
-      selectedLevels,
-      selectedDevices,
-      logDeviceIds,
-      filteredLogs.length,
-      hasActiveFilter,
-      handleClearData,
-      handleTypeSelect,
-      handleLevelSelect,
-      handleDeviceSelect,
-      handleClearSearch,
-      toggleFilter,
-      arrowStyle,
-      contentStyle,
-      colors.muted,
-    ]
-  );
 
-  const ListEmpty = useMemo(
-    () => (
-      <View className="flex-1 items-center justify-center py-20">
-        <Text style={{ fontSize: 64, lineHeight: 80 }} className="mb-4">📝</Text>
-        <Text className="text-lg font-semibold text-foreground mb-2">
-          {hasActiveFilter
-            ? "条件に一致するログがありません"
-            : "ログがありません"}
-        </Text>
-        <Text className="text-sm text-muted text-center px-8">
-          {hasActiveFilter
-            ? "フィルター条件を変更してください"
-            : "WebSocketに接続してログデータを受信してください"}
-        </Text>
-      </View>
-    ),
-    [hasActiveFilter]
-  );
-
-  return (
-    <ScreenContainer>
       <FlatList
         data={filteredLogs}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        ListHeaderComponent={ListHeader}
         ListEmptyComponent={ListEmpty}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
+        // スクロール中に先頭へアイテムが追加されてもスクロール位置を維持する
+        maintainVisibleContentPosition={{
+          minIndexForVisible: 0,
+        }}
         // パフォーマンス最適化
         initialNumToRender={10}
         maxToRenderPerBatch={5}
@@ -574,8 +554,14 @@ export default function LogsScreen() {
 }
 
 const styles = StyleSheet.create({
+  stickyHeader: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 8,
+  },
   listContent: {
-    padding: 16,
+    paddingHorizontal: 16,
+    paddingTop: 8,
     paddingBottom: 100,
   },
   filterScrollContent: {

--- a/app/(tabs)/logs.tsx
+++ b/app/(tabs)/logs.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useRef } from "react";
 import {
   Text,
   View,
@@ -9,6 +9,8 @@ import {
   Alert,
   ScrollView,
   TextInput,
+  type NativeSyntheticEvent,
+  type NativeScrollEvent,
 } from "react-native";
 import * as Haptics from "expo-haptics";
 import Animated, {
@@ -234,6 +236,36 @@ export default function LogsScreen() {
   const handleClearSearch = useCallback(() => {
     setSearchQuery("");
   }, []);
+
+  // Web fallback for maintainVisibleContentPosition (not supported in react-native-web)
+  const isWeb = Platform.OS === "web";
+  const listRef = useRef<FlatList<LogData>>(null);
+  const webScrollState = useRef({ offset: 0, contentHeight: 0 });
+
+  const handleWebScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      webScrollState.current.offset = e.nativeEvent.contentOffset.y;
+    },
+    []
+  );
+
+  const handleWebContentSizeChange = useCallback(
+    (_w: number, h: number) => {
+      const prev = webScrollState.current;
+      if (prev.contentHeight > 0 && prev.offset > 0) {
+        const delta = h - prev.contentHeight;
+        if (delta > 0) {
+          listRef.current?.scrollToOffset({
+            offset: prev.offset + delta,
+            animated: false,
+          });
+          prev.offset += delta;
+        }
+      }
+      prev.contentHeight = h;
+    },
+    []
+  );
 
   const renderItem = useCallback(
     ({ item }: { item: LogData }) => (
@@ -530,6 +562,7 @@ export default function LogsScreen() {
       </View>
 
       <FlatList
+        ref={isWeb ? listRef : undefined}
         data={filteredLogs}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
@@ -537,9 +570,15 @@ export default function LogsScreen() {
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
         // スクロール中に先頭へアイテムが追加されてもスクロール位置を維持する
-        maintainVisibleContentPosition={{
-          minIndexForVisible: 0,
-        }}
+        // react-native-web では未サポートのため web 向けは手動で補正する
+        {...(!isWeb && {
+          maintainVisibleContentPosition: { minIndexForVisible: 0 },
+        })}
+        {...(isWeb && {
+          onScroll: handleWebScroll,
+          onContentSizeChange: handleWebContentSizeChange,
+          scrollEventThrottle: 16,
+        })}
         // パフォーマンス最適化
         initialNumToRender={10}
         maxToRenderPerBatch={5}

--- a/app/(tabs)/logs.tsx
+++ b/app/(tabs)/logs.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useRef } from "react";
+import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import {
   Text,
   View,
@@ -240,7 +240,22 @@ export default function LogsScreen() {
   // Web fallback for maintainVisibleContentPosition (not supported in react-native-web)
   const isWeb = Platform.OS === "web";
   const listRef = useRef<FlatList<LogData>>(null);
-  const webScrollState = useRef({ offset: 0, contentHeight: 0 });
+  const webScrollState = useRef({ offset: 0, contentHeight: 0, isPrepend: false });
+  const prevFirstIdRef = useRef<string | undefined>(undefined);
+
+  // Detect when items are prepended (first item ID changes while list grows)
+  useEffect(() => {
+    if (!isWeb) return;
+    const firstId = filteredLogs.length > 0 ? filteredLogs[0].id : undefined;
+    if (
+      prevFirstIdRef.current !== undefined &&
+      firstId !== undefined &&
+      firstId !== prevFirstIdRef.current
+    ) {
+      webScrollState.current.isPrepend = true;
+    }
+    prevFirstIdRef.current = firstId;
+  }, [isWeb, filteredLogs]);
 
   const handleWebScroll = useCallback(
     (e: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -252,7 +267,7 @@ export default function LogsScreen() {
   const handleWebContentSizeChange = useCallback(
     (_w: number, h: number) => {
       const prev = webScrollState.current;
-      if (prev.contentHeight > 0 && prev.offset > 0) {
+      if (prev.isPrepend && prev.contentHeight > 0 && prev.offset > 0) {
         const delta = h - prev.contentHeight;
         if (delta > 0) {
           listRef.current?.scrollToOffset({
@@ -261,6 +276,7 @@ export default function LogsScreen() {
           });
           prev.offset += delta;
         }
+        prev.isPrepend = false;
       }
       prev.contentHeight = h;
     },

--- a/app/(tabs)/timeline.tsx
+++ b/app/(tabs)/timeline.tsx
@@ -565,6 +565,10 @@ export default function TimelineScreen() {
         ListEmptyComponent={ListEmpty}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
+        // スクロール中に先頭へアイテムが追加されてもスクロール位置を維持する
+        maintainVisibleContentPosition={{
+          minIndexForVisible: 0,
+        }}
         // パフォーマンス最適化
         initialNumToRender={10}
         maxToRenderPerBatch={5}

--- a/app/(tabs)/timeline.tsx
+++ b/app/(tabs)/timeline.tsx
@@ -236,9 +236,29 @@ export default function TimelineScreen() {
 
   const keyExtractor = useCallback((item: LocationUpdate) => item.id, []);
 
-  const ListHeader = useMemo(
+  const ListEmpty = useMemo(
     () => (
-      <View className="mb-4">
+      <View className="flex-1 items-center justify-center py-20">
+        <Text style={{ fontSize: 64, lineHeight: 80 }} className="mb-4">📍</Text>
+        <Text className="text-lg font-semibold text-foreground mb-2">
+          {hasActiveFilter
+            ? "条件に一致するデータがありません"
+            : "データがありません"}
+        </Text>
+        <Text className="text-sm text-muted text-center px-8">
+          {hasActiveFilter
+            ? "フィルター条件を変更してください"
+            : "WebSocketに接続して位置情報データを受信してください"}
+        </Text>
+      </View>
+    ),
+    [hasActiveFilter]
+  );
+
+  return (
+    <ScreenContainer>
+      {/* ヘッダー部分（スクロールに追従して固定表示） */}
+      <View style={styles.stickyHeader}>
         {/* Header with status */}
         <View className="flex-row justify-between items-center mb-4">
           <Text className="text-2xl font-bold text-foreground">タイムライン</Text>
@@ -510,58 +530,11 @@ export default function TimelineScreen() {
           )}
         </View>
       </View>
-    ),
-    [
-      state.connectionStatus,
-      state.deviceIds,
-      state.lineIds,
-      lineNames,
-      lineColors,
-      state.updates.length,
-      searchQuery,
-      selectedStates,
-      selectedDevices,
-      selectedRoutes,
-      filteredUpdates.length,
-      hasActiveFilter,
-      handleClearData,
-      handleStateSelect,
-      handleDeviceSelect,
-      handleRouteSelect,
-      handleClearSearch,
-      toggleFilter,
-      arrowStyle,
-      contentStyle,
-      colors.muted,
-    ]
-  );
 
-  const ListEmpty = useMemo(
-    () => (
-      <View className="flex-1 items-center justify-center py-20">
-        <Text style={{ fontSize: 64, lineHeight: 80 }} className="mb-4">📍</Text>
-        <Text className="text-lg font-semibold text-foreground mb-2">
-          {hasActiveFilter
-            ? "条件に一致するデータがありません"
-            : "データがありません"}
-        </Text>
-        <Text className="text-sm text-muted text-center px-8">
-          {hasActiveFilter
-            ? "フィルター条件を変更してください"
-            : "WebSocketに接続して位置情報データを受信してください"}
-        </Text>
-      </View>
-    ),
-    [hasActiveFilter]
-  );
-
-  return (
-    <ScreenContainer>
       <FlatList
         data={filteredUpdates}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        ListHeaderComponent={ListHeader}
         ListEmptyComponent={ListEmpty}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
@@ -581,8 +554,14 @@ export default function TimelineScreen() {
 }
 
 const styles = StyleSheet.create({
+  stickyHeader: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 8,
+  },
   listContent: {
-    padding: 16,
+    paddingHorizontal: 16,
+    paddingTop: 8,
     paddingBottom: 100,
   },
   filterScrollContent: {

--- a/lib/__tests__/location-store.test.ts
+++ b/lib/__tests__/location-store.test.ts
@@ -122,6 +122,10 @@ const createMockLog = (overrides: Partial<LogData> = {}): LogData => ({
 });
 
 describe("Location Store Reducer", () => {
+  beforeEach(() => {
+    logIdCounter = 0;
+  });
+
   describe("ADD_UPDATE", () => {
     it("should add a new location update to the beginning of the list", () => {
       const update = createMockUpdate({ id: "update-1" });
@@ -248,8 +252,11 @@ describe("Location Store Reducer", () => {
     it("should generate a stable ID when payload.id is missing", () => {
       const log = createMockLog();
       // Simulate server sending a log without an id field
-      const logWithoutId = { ...log, id: "" } as LogData;
-      const action: LocationAction = { type: "ADD_LOG", payload: logWithoutId };
+      const { id: _removed, ...logWithoutId } = log;
+      const action: LocationAction = {
+        type: "ADD_LOG",
+        payload: logWithoutId as LogData,
+      };
 
       const newState = locationReducer(initialState, action);
 
@@ -258,6 +265,7 @@ describe("Location Store Reducer", () => {
       expect(newState.logs[0].id).toMatch(/^log-gen-/);
       expect(newState.logs[0].device).toBe(log.device);
       expect(newState.logs[0].log.message).toBe(log.log.message);
+      expect(newState.messageCount).toBe(initialState.messageCount + 1);
     });
 
     it("should limit logs to 500 per device", () => {

--- a/lib/__tests__/location-store.test.ts
+++ b/lib/__tests__/location-store.test.ts
@@ -12,6 +12,8 @@ import type {
 const MAX_UPDATES_PER_DEVICE = 500;
 const MAX_LOGS_PER_DEVICE = 500;
 
+let logIdCounter = 0;
+
 function enforcePerDeviceLimit<T extends { device: string }>(
   items: T[],
   maxPerDevice: number
@@ -51,7 +53,7 @@ function locationReducer(state: LocationState, action: LocationAction): Location
     case "ADD_LOG": {
       const log = action.payload.id
         ? action.payload
-        : { ...action.payload, id: `log-gen-test-${Date.now()}` };
+        : { ...action.payload, id: `log-gen-${++logIdCounter}` };
       const newLogs = enforcePerDeviceLimit(
         [log, ...state.logs],
         MAX_LOGS_PER_DEVICE
@@ -59,6 +61,7 @@ function locationReducer(state: LocationState, action: LocationAction): Location
       return {
         ...state,
         logs: newLogs,
+        messageCount: state.messageCount + 1,
       };
     }
     case "SET_CONNECTION_STATUS":
@@ -240,6 +243,21 @@ describe("Location Store Reducer", () => {
       
       expect(newState.logs).toHaveLength(1);
       expect(newState.logs[0]).toEqual(log);
+    });
+
+    it("should generate a stable ID when payload.id is missing", () => {
+      const log = createMockLog();
+      // Simulate server sending a log without an id field
+      const logWithoutId = { ...log, id: "" } as LogData;
+      const action: LocationAction = { type: "ADD_LOG", payload: logWithoutId };
+
+      const newState = locationReducer(initialState, action);
+
+      expect(newState.logs).toHaveLength(1);
+      expect(newState.logs[0].id).toBeTruthy();
+      expect(newState.logs[0].id).toMatch(/^log-gen-/);
+      expect(newState.logs[0].device).toBe(log.device);
+      expect(newState.logs[0].log.message).toBe(log.log.message);
     });
 
     it("should limit logs to 500 per device", () => {

--- a/lib/__tests__/location-store.test.ts
+++ b/lib/__tests__/location-store.test.ts
@@ -247,6 +247,7 @@ describe("Location Store Reducer", () => {
       
       expect(newState.logs).toHaveLength(1);
       expect(newState.logs[0]).toEqual(log);
+      expect(newState.messageCount).toBe(initialState.messageCount + 1);
     });
 
     it("should generate a stable ID when payload.id is missing", () => {

--- a/lib/__tests__/location-store.test.ts
+++ b/lib/__tests__/location-store.test.ts
@@ -49,7 +49,9 @@ function locationReducer(state: LocationState, action: LocationAction): Location
       };
     }
     case "ADD_LOG": {
-      const log = action.payload;
+      const log = action.payload.id
+        ? action.payload
+        : { ...action.payload, id: `log-gen-test-${Date.now()}` };
       const newLogs = enforcePerDeviceLimit(
         [log, ...state.logs],
         MAX_LOGS_PER_DEVICE

--- a/lib/location-store.tsx
+++ b/lib/location-store.tsx
@@ -16,6 +16,8 @@ const WS_PROTOCOLS = ["thq", `thq-auth-${WS_AUTH_TOKEN}`];
 const MAX_UPDATES_PER_DEVICE = 500; // デバイスごとに保持する最大更新数
 const MAX_LOGS_PER_DEVICE = 500; // デバイスごとに保持する最大ログ数
 
+let logIdCounter = 0;
+
 /**
  * デバイスごとに最大件数を制限する
  * 配列の先頭が最新なので、先頭から数えて制限を超えた古いエントリを除外する
@@ -73,7 +75,9 @@ function locationReducer(state: LocationState, action: LocationAction): Location
       };
     }
     case "ADD_LOG": {
-      const log = action.payload;
+      const log = action.payload.id
+        ? action.payload
+        : { ...action.payload, id: `log-gen-${++logIdCounter}` };
       const newLogs = enforcePerDeviceLimit(
         [log, ...state.logs],
         MAX_LOGS_PER_DEVICE


### PR DESCRIPTION
## Summary
- FlatListに`maintainVisibleContentPosition`を追加し、スクロール中に新しいデータが先頭に追加されてもスクロール位置を維持するように修正
- タイムライン・ログ画面のヘッダー（タイトル、検索、フィルター、件数表示）をFlatListの外に移動し、スクロールしても常に画面上部に固定表示されるように変更

## Test plan
- [ ] タイムライン画面でスクロール後にWebSocketで新データが入った際、リストがガタつかないことを確認
- [ ] タイムライン画面でリストをスクロールしても、ヘッダー（検索・フィルター・件数）が上部に固定されていることを確認
- [ ] ログ画面でも同様にヘッダーが固定表示されることを確認
- [ ] フィルターのアコーディオン開閉が正常に動作することを確認
- [ ] iOS / Android / Web で表示が崩れないことを確認

https://claude.ai/code/session_01MPkqpw4PNwHcRH6Gb74HD9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ヘッダー（状態表示・検索・フィルター）をリスト上部の固定領域（sticky header）に移動し常時表示するようにしました
  * Web向けのスクロール補助（カスタムonScroll/onContentSizeChange）を追加しました
* **改善**
  * 空状態表示をListHeaderからListEmptyに置換し、フィルター有無で表示を切替
  * 項目追加時のスクロール維持をプラットフォーム別に最適化（非WebはmaintainVisibleContentPosition）
  * レイアウト余白・表示順を調整
* **バグ修正**
  * IDが欠ける新規ログに一貫した生成IDを割当て
* **テスト**
  * 新しいID生成を検証するテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->