### PR TITLE
fix(logs): FlatListにflex:1を追加しフィルターのスクロール追従を修正

### DIFF
--- a/app/(tabs)/logs.tsx
+++ b/app/(tabs)/logs.tsx
@@ -315,7 +315,7 @@ export default function LogsScreen() {
 
   return (
     <ScreenContainer>
-      {/* ヘッダー部分（スクロールに追従して固定表示） */}
+      {/* ヘッダー部分（タイトル・検索のみ固定表示） */}
       <View style={styles.stickyHeader}>
         {/* Header with status */}
         <View className="flex-row justify-between items-center mb-4">
@@ -344,55 +344,64 @@ export default function LogsScreen() {
           )}
         </View>
 
-        {/* Filter Accordion */}
-        <View className="mb-4 bg-surface rounded-xl border border-border overflow-hidden">
-          {/* Accordion Header */}
-          <TouchableOpacity
-            onPress={toggleFilter}
-            activeOpacity={0.7}
-            style={styles.accordionHeader}
-          >
-            <View className="flex-1 flex-row items-center justify-between px-4">
-              <View className="flex-row items-center">
-                <Text className="text-base font-medium text-foreground">
-                  フィルター
-                </Text>
-                {(selectedTypes.size > 0 || selectedLevels.size > 0 || selectedDevices.size > 0) && (
-                  <View className="ml-2 bg-primary px-2 py-0.5 rounded-full">
-                    <Text className="text-xs text-white font-medium">適用中</Text>
-                  </View>
-                )}
-              </View>
-              <Animated.Text style={[styles.arrowIcon, arrowStyle]}>
-                ▼
-              </Animated.Text>
-            </View>
-          </TouchableOpacity>
+      </View>
 
-          {/* Accordion Content with Animation */}
-          <Animated.View style={contentStyle}>
-            <View className="px-4 pb-4 border-t border-border">
-              {/* Type Filter */}
-              <View className="mt-3">
-                <Text className="text-sm text-muted mb-2">タイプ</Text>
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  contentContainerStyle={styles.filterScrollContent}
-                >
-                  {/* すべてボタン */}
-                  <TouchableOpacity
-                    onPress={() => handleTypeSelect(null)}
-                    activeOpacity={0.7}
-                    style={styles.filterButton}
-                  >
-                    <View
-                      className={cn(
-                        "px-3 py-2 rounded-full border",
-                        selectedTypes.size === 0
-                          ? "bg-primary border-primary"
-                          : "bg-background border-border"
-                      )}
+      <FlatList
+        ref={isWeb ? listRef : undefined}
+        data={filteredLogs}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        ListHeaderComponent={
+          <View style={styles.listHeaderContent}>
+            {/* Filter Accordion */}
+            <View className="mb-4 bg-surface rounded-xl border border-border overflow-hidden">
+              {/* Accordion Header */}
+              <TouchableOpacity
+                onPress={toggleFilter}
+                activeOpacity={0.7}
+                style={styles.accordionHeader}
+              >
+                <View className="flex-1 flex-row items-center justify-between px-4">
+                  <View className="flex-row items-center">
+                    <Text className="text-base font-medium text-foreground">
+                      フィルター
+                    </Text>
+                    {(selectedTypes.size > 0 || selectedLevels.size > 0 || selectedDevices.size > 0) && (
+                      <View className="ml-2 bg-primary px-2 py-0.5 rounded-full">
+                        <Text className="text-xs text-white font-medium">適用中</Text>
+                      </View>
+                    )}
+                  </View>
+                  <Animated.Text style={[styles.arrowIcon, arrowStyle]}>
+                    ▼
+                  </Animated.Text>
+                </View>
+              </TouchableOpacity>
+
+              {/* Accordion Content with Animation */}
+              <Animated.View style={contentStyle}>
+                <View className="px-4 pb-4 border-t border-border">
+                  {/* Type Filter */}
+                  <View className="mt-3">
+                    <Text className="text-sm text-muted mb-2">タイプ</Text>
+                    <ScrollView
+                      horizontal
+                      showsHorizontalScrollIndicator={false}
+                      contentContainerStyle={styles.filterScrollContent}
+                    >
+                      {/* すべてボタン */}
+                      <TouchableOpacity
+                        onPress={() => handleTypeSelect(null)}
+                        activeOpacity={0.7}
+                        style={styles.filterButton}
+                      >
+                        <View
+                          className={cn(
+                            "px-3 py-2 rounded-full border",
+                            selectedTypes.size === 0
+                              ? "bg-primary border-primary"
+                              : "bg-background border-border"
+                          )}
                     >
                       <Text
                         className={cn(
@@ -557,31 +566,26 @@ export default function LogsScreen() {
                   </ScrollView>
                 </View>
               )}
+                </View>
+              </Animated.View>
             </View>
-          </Animated.View>
-        </View>
 
-        {/* Count info */}
-        <View className="flex-row justify-between items-center">
-          <Text className="text-sm text-muted">
-            {filteredLogs.length} 件のログ
-            {hasActiveFilter && (
-              <Text className="text-muted"> (全{state.logs.length}件)</Text>
-            )}
-          </Text>
-          {state.logs.length > 0 && (
-            <TouchableOpacity onPress={handleClearData} activeOpacity={0.7}>
-              <Text className="text-sm text-error">クリア</Text>
-            </TouchableOpacity>
-          )}
-        </View>
-      </View>
-
-      <FlatList
-        ref={isWeb ? listRef : undefined}
-        data={filteredLogs}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
+            {/* Count info */}
+            <View className="flex-row justify-between items-center">
+              <Text className="text-sm text-muted">
+                {filteredLogs.length} 件のログ
+                {hasActiveFilter && (
+                  <Text className="text-muted"> (全{state.logs.length}件)</Text>
+                )}
+              </Text>
+              {state.logs.length > 0 && (
+                <TouchableOpacity onPress={handleClearData} activeOpacity={0.7}>
+                  <Text className="text-sm text-error">クリア</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          </View>
+        }
         ListEmptyComponent={ListEmpty}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
@@ -616,6 +620,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 8,
     paddingBottom: 100,
+  },
+  listHeaderContent: {
+    paddingBottom: 8,
   },
   filterScrollContent: {
     gap: 8,

--- a/app/(tabs)/logs.tsx
+++ b/app/(tabs)/logs.tsx
@@ -348,6 +348,7 @@ export default function LogsScreen() {
 
       <FlatList
         ref={isWeb ? listRef : undefined}
+        style={styles.list}
         data={filteredLogs}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
@@ -615,6 +616,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 16,
     paddingBottom: 8,
+  },
+  list: {
+    flex: 1,
   },
   listContent: {
     paddingHorizontal: 16,


### PR DESCRIPTION
## Summary
- FlatList に `flex: 1` を追加し、スティッキーヘッダー下の残りスペースに制約されるように修正
- これにより `ListHeaderComponent` 内のフィルターアコーディオンと件数表示がリストと一緒にスクロールするようになった

## Test plan
- [ ] ログ画面でスクロールし、フィルターと件数がリストと一緒に流れることを確認
- [ ] タイトルと検索ボックスが固定表示のままであることを確認
- [ ] フィルター操作が正常に動作することを確認

https://claude.ai/code/session_01MPkqpw4PNwHcRH6Gb74HD9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ログ画面のフィルター UI を再構成しました。フィルターがスクロール可能なリスト内に統合され、より効率的なレイアウトになりました。検索機能と基本的な操作性は変わりません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->