### PR TITLE
fix(logs): FlatListにflex:1を追加しフィルターのスクロール追従を修正

### DIFF
--- a/app/(tabs)/logs.tsx
+++ b/app/(tabs)/logs.tsx
@@ -348,6 +348,7 @@ export default function LogsScreen() {
 
       <FlatList
         ref={isWeb ? listRef : undefined}
+        style={styles.list}
         data={filteredLogs}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
@@ -615,6 +616,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 16,
     paddingBottom: 8,
+  },
+  list: {
+    flex: 1,
   },
   listContent: {
     paddingHorizontal: 16,


### PR DESCRIPTION
## Summary
- FlatList に `style={{ flex: 1 }}` を追加し、スティッキーヘッダー下の残りスペースに制約されるように修正
- これにより `ListHeaderComponent` 内のフィルターアコーディオンと件数表示がリストと一緒にスクロールするようになった

## Test plan
- [ ] ログ画面でスクロールし、フィルターと件数がリストと一緒に流れることを確認
- [ ] タイトルと検索ボックスが固定表示のままであることを確認
- [ ] フィルター操作が正常に動作することを確認

https://claude.ai/code/session_01MPkqpw4PNwHcRH6Gb74HD9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * ログス画面のレイアウト調整を改善しました。リストコンポーネントのスタイリングを最適化し、画面表示をより適切に配置しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->