### PR TITLE
接続ステータスバッジの左に現在時刻を表示

### DIFF
--- a/components/connection-status.tsx
+++ b/components/connection-status.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { View, Text } from "react-native";
 import type { ConnectionStatus } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
@@ -13,21 +14,44 @@ const statusConfig: Record<ConnectionStatus, { label: string; bgClass: string; t
   error: { label: "エラー", bgClass: "bg-error/20", textClass: "text-error" },
 };
 
+function useCurrentTime() {
+  const [time, setTime] = useState(() => {
+    const now = new Date();
+    return `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  });
+
+  useEffect(() => {
+    const update = () => {
+      const now = new Date();
+      setTime(`${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`);
+    };
+
+    const intervalId = setInterval(update, 1000);
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return time;
+}
+
 export function ConnectionStatusBadge({ status }: ConnectionStatusBadgeProps) {
   const config = statusConfig[status];
+  const currentTime = useCurrentTime();
 
   return (
-    <View className={cn("flex-row items-center px-3 py-1.5 rounded-full", config.bgClass)}>
-      <View
-        className={cn(
-          "w-2 h-2 rounded-full mr-2",
-          status === "connected" && "bg-success",
-          status === "connecting" && "bg-warning",
-          status === "disconnected" && "bg-muted",
-          status === "error" && "bg-error"
-        )}
-      />
-      <Text className={cn("text-sm font-medium", config.textClass)}>{config.label}</Text>
+    <View className="flex-row items-center gap-2">
+      <Text className="text-sm font-bold text-black">{currentTime}</Text>
+      <View className={cn("flex-row items-center px-3 py-1.5 rounded-full", config.bgClass)}>
+        <View
+          className={cn(
+            "w-2 h-2 rounded-full mr-2",
+            status === "connected" && "bg-success",
+            status === "connecting" && "bg-warning",
+            status === "disconnected" && "bg-muted",
+            status === "error" && "bg-error"
+          )}
+        />
+        <Text className={cn("text-sm font-medium", config.textClass)}>{config.label}</Text>
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- `ConnectionStatusBadge` コンポーネントの左側にHH:MM形式の現在時刻を黒太字で表示
- 毎秒更新される `useCurrentTime` カスタムフックを追加
- 表示イメージ: **14:30** 🟢接続中

## Test plan
- [ ] 各タブ画面（ホーム、タイムライン、マップ、ログ）で時刻が正しく表示されることを確認
- [ ] 分が変わるタイミングで表示が更新されることを確認
- [ ] 時刻がHH:MM形式（ゼロ埋め）で表示されることを確認

https://claude.ai/code/session_013c5LALGj8qiwvjnxHVggfE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 接続ステータスコンポーネントに現在時刻のリアルタイム表示機能を追加しました。時刻は毎秒自動更新されます。
  * ステータスバッジと時刻表示の間に余白を挿入し、ユーザーインターフェースの視認性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->