### PR TITLE
fix: タイムラインのデバイス名が長い場合にレイアウト崩れを防止

### DIFF
--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -135,7 +135,7 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
             🕐 {formatDate(update.timestamp)} {formatTimestamp(update.timestamp)}
           </Text>
         </View>
-        <View className="flex-row items-center gap-2">
+        <View className="flex-row items-center gap-2 flex-shrink" style={{ maxWidth: "55%" }}>
           <View
             className={cn("px-2 py-0.5 rounded-full", stateConf.bgClass)}
             style={{ borderWidth: 1, borderColor }}
@@ -144,7 +144,7 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
               {stateLabel}
             </Text>
           </View>
-          <Text className="text-muted text-base" numberOfLines={1}>
+          <Text className="text-muted text-base flex-shrink" numberOfLines={1} ellipsizeMode="tail">
             {update.device}
           </Text>
         </View>


### PR DESCRIPTION
右側コンテナにmaxWidthとflex-shrinkを設定し、デバイス名テキストに
ellipsizeModeを追加して長い名前（例: iPad (7th generation)）を
省略表示するように修正。

https://claude.ai/code/session_01Ais1HRr9yybTsCWZhLrBrb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * ロケーションカードのレイアウト表示を最適化しました。長いテキストが自動的に切り詰められるようになり、より整理された表示になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->