### PR TITLE
fix: デバイス名のレイアウト崩れ修正と再利用可能なTooltipコンポーネントの追加

### DIFF
--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -1,5 +1,5 @@
-import { memo, useMemo } from "react";
-import { View, Text } from "react-native";
+import { memo, useMemo, useState } from "react";
+import { View, Text, Pressable } from "react-native";
 import type { LocationUpdate, MovingState, BatteryState } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 import { useColors } from "@/hooks/use-colors";
@@ -122,6 +122,7 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
   const lineIds = useMemo(() => (update.line_id ? [update.line_id] : []), [update.line_id]);
   const lineNames = useLineNames(lineIds);
   // stateConfigに存在しない値の場合はフォールバックを使用
+  const [showDeviceTooltip, setShowDeviceTooltip] = useState(false);
   const stateConf = stateConfig[update.state as MovingState] || defaultStateConfig;
   const stateLabel = stateConf.label === "不明" && update.state ? String(update.state) : stateConf.label;
   const borderColor = colors[stateConf.colorKey];
@@ -141,9 +142,17 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
             {stateLabel}
           </Text>
         </View>
-        <Text className="text-muted text-base flex-1 flex-shrink" numberOfLines={1} ellipsizeMode="tail">
-          {update.device}
-        </Text>
+        <Pressable className="flex-1 flex-shrink" onPress={() => setShowDeviceTooltip((v) => !v)}>
+          <Text className="text-muted text-base" numberOfLines={1} ellipsizeMode="tail">
+            {update.device}
+          </Text>
+          {showDeviceTooltip && (
+            <View className="absolute top-full mt-1 right-0 bg-foreground rounded-lg px-3 py-1.5 z-50" style={{ elevation: 4 }}>
+              <Text className="text-background text-sm">{update.device}</Text>
+              <View className="absolute -top-1.5 right-3 w-3 h-3 bg-foreground rotate-45" />
+            </View>
+          )}
+        </Pressable>
       </View>
 
       {/* Route Name */}

--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -1,5 +1,6 @@
-import { memo, useMemo, useState } from "react";
-import { View, Text, Pressable } from "react-native";
+import { memo, useMemo } from "react";
+import { View, Text } from "react-native";
+import { Tooltip } from "@/components/ui/tooltip";
 import type { LocationUpdate, MovingState, BatteryState } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 import { useColors } from "@/hooks/use-colors";
@@ -122,7 +123,6 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
   const lineIds = useMemo(() => (update.line_id ? [update.line_id] : []), [update.line_id]);
   const lineNames = useLineNames(lineIds);
   // stateConfigに存在しない値の場合はフォールバックを使用
-  const [showDeviceTooltip, setShowDeviceTooltip] = useState(false);
   const stateConf = stateConfig[update.state as MovingState] || defaultStateConfig;
   const stateLabel = stateConf.label === "不明" && update.state ? String(update.state) : stateConf.label;
   const borderColor = colors[stateConf.colorKey];
@@ -142,17 +142,11 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
             {stateLabel}
           </Text>
         </View>
-        <Pressable className="flex-1 flex-shrink" onPress={() => setShowDeviceTooltip((v) => !v)}>
+        <Tooltip text={update.device} className="flex-1 flex-shrink">
           <Text className="text-muted text-base" numberOfLines={1} ellipsizeMode="tail">
             {update.device}
           </Text>
-          {showDeviceTooltip && (
-            <View className="absolute top-full mt-1 right-0 bg-foreground rounded-lg px-3 py-1.5 z-50" style={{ elevation: 4 }}>
-              <Text className="text-background text-sm">{update.device}</Text>
-              <View className="absolute -top-1.5 right-3 w-3 h-3 bg-foreground rotate-45" />
-            </View>
-          )}
-        </Pressable>
+        </Tooltip>
       </View>
 
       {/* Route Name */}

--- a/components/location-card.tsx
+++ b/components/location-card.tsx
@@ -128,26 +128,22 @@ export const LocationCard = memo(function LocationCard({ update }: LocationCardP
 
   return (
     <View className="bg-surface rounded-xl p-4 border border-border">
-      {/* Header: DateTime + Device + State Badge */}
-      <View className="flex-row justify-between items-center mb-1">
-        <View className="flex-row items-center">
-          <Text className="text-foreground font-semibold text-base">
-            🕐 {formatDate(update.timestamp)} {formatTimestamp(update.timestamp)}
+      {/* Header: DateTime + State Badge + Device */}
+      <View className="flex-row items-center mb-1 gap-2">
+        <Text className="text-foreground font-semibold text-base">
+          🕐 {formatDate(update.timestamp)} {formatTimestamp(update.timestamp)}
+        </Text>
+        <View
+          className={cn("px-2 py-0.5 rounded-full", stateConf.bgClass)}
+          style={{ borderWidth: 1, borderColor }}
+        >
+          <Text className={cn("text-base font-medium", stateConf.textClass)}>
+            {stateLabel}
           </Text>
         </View>
-        <View className="flex-row items-center gap-2 flex-shrink" style={{ maxWidth: "55%" }}>
-          <View
-            className={cn("px-2 py-0.5 rounded-full", stateConf.bgClass)}
-            style={{ borderWidth: 1, borderColor }}
-          >
-            <Text className={cn("text-base font-medium", stateConf.textClass)}>
-              {stateLabel}
-            </Text>
-          </View>
-          <Text className="text-muted text-base flex-shrink" numberOfLines={1} ellipsizeMode="tail">
-            {update.device}
-          </Text>
-        </View>
+        <Text className="text-muted text-base flex-1 flex-shrink" numberOfLines={1} ellipsizeMode="tail">
+          {update.device}
+        </Text>
       </View>
 
       {/* Route Name */}

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,6 +1,10 @@
-import { useState, type ReactNode } from "react";
-import { View, Text, Pressable } from "react-native";
+import { useState, useRef, useCallback, type ReactNode } from "react";
+import { View, Text, Pressable, Modal, StyleSheet } from "react-native";
 import { cn } from "@/lib/utils";
+import { useColors } from "@/hooks/use-colors";
+
+const ARROW_SIZE = 6;
+const TOOLTIP_OFFSET = 4;
 
 interface TooltipProps {
   text: string;
@@ -10,19 +14,87 @@ interface TooltipProps {
 
 export function Tooltip({ text, children, className }: TooltipProps) {
   const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0, width: 0 });
+  const triggerRef = useRef<View>(null);
+  const colors = useColors();
+
+  const handleOpen = useCallback(() => {
+    triggerRef.current?.measureInWindow((x, y, width, height) => {
+      setPosition({ x, y: y + height + TOOLTIP_OFFSET + ARROW_SIZE, width });
+      setVisible(true);
+    });
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setVisible(false);
+  }, []);
 
   return (
-    <Pressable className={cn(className)} onPress={() => setVisible((v) => !v)}>
-      {children}
-      {visible && (
-        <View
-          className="absolute top-full mt-1 right-0 bg-foreground rounded-lg px-3 py-1.5 z-50"
-          style={{ elevation: 4 }}
-        >
-          <Text className="text-background text-sm">{text}</Text>
-          <View className="absolute -top-1.5 right-3 w-3 h-3 bg-foreground rotate-45" />
-        </View>
-      )}
-    </Pressable>
+    <>
+      <Pressable
+        ref={triggerRef}
+        className={cn(className)}
+        onPress={handleOpen}
+        accessibilityRole="button"
+        accessibilityHint="ツールチップを表示します"
+      >
+        {children}
+      </Pressable>
+      <Modal visible={visible} transparent animationType="fade">
+        <Pressable style={styles.overlay} onPress={handleClose}>
+          <View
+            style={[
+              styles.tooltip,
+              {
+                top: position.y,
+                right: 16,
+                backgroundColor: colors.foreground,
+              },
+            ]}
+          >
+            <View
+              style={[
+                styles.arrow,
+                {
+                  top: -ARROW_SIZE,
+                  right: position.width / 2 - ARROW_SIZE,
+                  borderBottomColor: colors.foreground,
+                },
+              ]}
+            />
+            <Text style={{ color: colors.background, fontSize: 14 }}>
+              {text}
+            </Text>
+          </View>
+        </Pressable>
+      </Modal>
+    </>
   );
 }
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+  },
+  tooltip: {
+    position: "absolute",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    elevation: 4,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+  },
+  arrow: {
+    position: "absolute",
+    width: 0,
+    height: 0,
+    borderLeftWidth: ARROW_SIZE,
+    borderRightWidth: ARROW_SIZE,
+    borderBottomWidth: ARROW_SIZE,
+    borderLeftColor: "transparent",
+    borderRightColor: "transparent",
+  },
+});

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+import { useState, type ReactNode } from "react";
+import { View, Text, Pressable } from "react-native";
+import { cn } from "@/lib/utils";
+
+interface TooltipProps {
+  text: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function Tooltip({ text, children, className }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <Pressable className={cn(className)} onPress={() => setVisible((v) => !v)}>
+      {children}
+      {visible && (
+        <View
+          className="absolute top-full mt-1 right-0 bg-foreground rounded-lg px-3 py-1.5 z-50"
+          style={{ elevation: 4 }}
+        >
+          <Text className="text-background text-sm">{text}</Text>
+          <View className="absolute -top-1.5 right-3 w-3 h-3 bg-foreground rotate-45" />
+        </View>
+      )}
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## Summary
- タイムラインカードのヘッダー行をフラットな `flex-row` に変更し、長いデバイス名による レイアウト崩れを修正
- 省略されたデバイス名をタップすると吹き出しで全名を表示する機能を追加
- 汎用的な `Tooltip` コンポーネント (`components/ui/tooltip.tsx`) を新規作成し、他の箇所でも再利用可能に

## Test plan
- [ ] 長いデバイス名（例: iPhone SE (3rd Generation)）でレイアウトが崩れないことを確認
- [ ] 省略表示されたデバイス名をタップするとツールチップが表示されることを確認
- [ ] 再タップでツールチップが非表示になることを確認
- [ ] 短いデバイス名の場合も正常に表示されることを確認

https://claude.ai/code/session_017LTorf1aXZd1RkxK9gRGUs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * デバイス情報にツールチップ機能を追加。デバイステキストにマウスを合わせると、フルデバイス名がポップアップで表示されるようになりました。

* **UI/UX Improvements**
  * ロケーションカードのヘッダーレイアウトを改善し、デバイス情報の表示をより見やすく整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->